### PR TITLE
Add voice agent prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-# expense-manager
+# Expense Manager Voice Agent
+
+This prototype demonstrates a basic voice-powered agent for documenting expenses. The agent listens to speech from the microphone, transcribes it, sends the text to OpenAI's API for a response and speaks the answer back to the user. The code uses `speech_recognition` for voice input and `pyttsx3` for text-to-speech.
+
+## Requirements
+
+- Python 3.8+
+- The packages listed in `requirements.txt`
+- An OpenAI API key exported as `OPENAI_API_KEY`
+
+Install dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running the Agent
+
+```bash
+python main.py
+```
+
+Say "exit" to stop the program.
+
+## Tests
+
+Unit tests use mocks so they run without audio hardware or network access:
+
+```bash
+pytest -q
+```

--- a/expense_manager/voice_agent.py
+++ b/expense_manager/voice_agent.py
@@ -1,0 +1,56 @@
+import os
+import openai
+import speech_recognition as sr
+import pyttsx3
+
+
+class VoiceAgent:
+    """A voice-powered agent that transcribes user input and responds using GPT."""
+
+    def __init__(self, openai_api_key: str):
+        openai.api_key = openai_api_key
+        self.recognizer = sr.Recognizer()
+        self.tts_engine = pyttsx3.init()
+
+    def listen(self) -> str:
+        with sr.Microphone() as source:
+            print("Listening...")
+            audio = self.recognizer.listen(source)
+        try:
+            text = self.recognizer.recognize_google(audio)
+            print(f"User said: {text}")
+            return text
+        except sr.UnknownValueError:
+            print("Could not understand audio")
+            return ""
+
+    def respond(self, prompt: str) -> str:
+        if not prompt:
+            return ""
+        completion = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo", messages=[{"role": "user", "content": prompt}]
+        )
+        answer = completion.choices[0].message["content"].strip()
+        print(f"Assistant: {answer}")
+        self.tts_engine.say(answer)
+        self.tts_engine.runAndWait()
+        return answer
+
+    def run(self):
+        while True:
+            prompt = self.listen()
+            if prompt.lower() in {"exit", "quit", "stop"}:
+                break
+            self.respond(prompt)
+
+
+def main():
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        raise ValueError("OPENAI_API_KEY environment variable not set")
+    agent = VoiceAgent(api_key)
+    agent.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/main.py
+++ b/main.py
@@ -1,0 +1,4 @@
+from expense_manager.voice_agent import main
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+openai>=1.0.0
+SpeechRecognition>=3.8.1
+pyttsx3>=2.90

--- a/tests/test_voice_agent.py
+++ b/tests/test_voice_agent.py
@@ -1,0 +1,39 @@
+import sys
+import types
+import unittest
+from unittest.mock import patch, MagicMock
+
+# Create dummy modules for external dependencies so the import works
+sys.modules['openai'] = types.ModuleType('openai')
+sys.modules['speech_recognition'] = types.ModuleType('speech_recognition')
+sys.modules['pyttsx3'] = types.ModuleType('pyttsx3')
+
+from expense_manager.voice_agent import VoiceAgent
+
+
+class TestVoiceAgent(unittest.TestCase):
+    @patch("expense_manager.voice_agent.sr")
+    @patch("expense_manager.voice_agent.openai")
+    @patch("expense_manager.voice_agent.pyttsx3")
+    def test_run_once(self, mock_tts, mock_openai, mock_sr):
+        recognizer = MagicMock()
+        recognizer.listen.return_value = "audio"
+        recognizer.recognize_google.return_value = "hello"
+        mock_sr.Recognizer.return_value = recognizer
+        microphone = MagicMock()
+        mock_sr.Microphone.return_value.__enter__.return_value = microphone
+
+        mock_openai.ChatCompletion.create.return_value = MagicMock(
+            choices=[MagicMock(message={"content": "hi there"})]
+        )
+        engine = MagicMock()
+        mock_tts.init.return_value = engine
+
+        agent = VoiceAgent("key")
+        with patch.object(agent, "listen", return_value="exit"):
+            agent.run()
+        engine.say.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add voice agent module using OpenAI and speech libs
- provide CLI entrypoint and installation instructions
- include unit tests for the agent
- ignore pycache files

## Testing
- `python -m unittest discover -v tests`