### PR TITLE
Add Vapi-based voice agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,45 @@
-# expense-manager
+# Expense Manager Voice Agent
+
+This prototype demonstrates a voice-powered agent for documenting expenses. Two implementations are provided:
+
+* **VoiceAgent** - uses local speech recognition and text-to-speech libraries.
+* **VapiAgent** - uses [Vapi](https://vapi.ai) APIs for speech input and output.
+
+Both agents send transcribed text to OpenAI and read the response aloud.
+
+## Requirements
+
+- Python 3.8+
+- The packages listed in `requirements.txt`
+- `OPENAI_API_KEY` exported in the environment
+- If using Vapi, also export `VAPI_API_KEY`
+
+Install dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running the Agent
+
+By default the local `VoiceAgent` is used:
+
+```bash
+python main.py
+```
+
+To run the Vapi-backed agent:
+
+```bash
+python main.py --vapi
+```
+
+Say "exit" to stop the program.
+
+## Tests
+
+Unit tests use mocks so they run without audio hardware or network access:
+
+```bash
+python -m unittest discover -v tests
+```

--- a/expense_manager/__init__.py
+++ b/expense_manager/__init__.py
@@ -1,0 +1,4 @@
+from .voice_agent import VoiceAgent
+from .vapi_agent import VapiAgent
+
+__all__ = ["VoiceAgent", "VapiAgent"]

--- a/expense_manager/vapi_agent.py
+++ b/expense_manager/vapi_agent.py
@@ -1,0 +1,70 @@
+import os
+import openai
+import requests
+import speech_recognition as sr
+
+
+class VapiAgent:
+    """Voice agent using Vapi for speech and OpenAI for chat."""
+
+    TRANSCRIBE_URL = "https://api.vapi.ai/v1/transcribe"
+    SPEAK_URL = "https://api.vapi.ai/v1/speak"
+
+    def __init__(self, openai_api_key: str, vapi_api_key: str):
+        openai.api_key = openai_api_key
+        self.vapi_api_key = vapi_api_key
+        self.recognizer = sr.Recognizer()
+
+    @property
+    def headers(self) -> dict:
+        return {"Authorization": f"Bearer {self.vapi_api_key}"}
+
+    def listen(self) -> str:
+        """Capture audio from the mic and transcribe using Vapi."""
+        with sr.Microphone() as source:
+            print("Listening...")
+            audio = self.recognizer.listen(source)
+        audio_bytes = audio.get_wav_data()
+        response = requests.post(
+            self.TRANSCRIBE_URL, headers=self.headers, files={"file": ("speech.wav", audio_bytes)}
+        )
+        response.raise_for_status()
+        text = response.json().get("text", "")
+        print(f"User said: {text}")
+        return text
+
+    def speak(self, text: str) -> None:
+        """Send text to Vapi for TTS playback."""
+        response = requests.post(self.SPEAK_URL, headers=self.headers, json={"text": text})
+        response.raise_for_status()
+
+    def respond(self, prompt: str) -> str:
+        if not prompt:
+            return ""
+        completion = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo", messages=[{"role": "user", "content": prompt}]
+        )
+        answer = completion.choices[0].message["content"].strip()
+        print(f"Assistant: {answer}")
+        self.speak(answer)
+        return answer
+
+    def run(self) -> None:
+        while True:
+            prompt = self.listen()
+            if prompt.lower() in {"exit", "quit", "stop"}:
+                break
+            self.respond(prompt)
+
+
+def main() -> None:
+    okey = os.environ.get("OPENAI_API_KEY")
+    vkey = os.environ.get("VAPI_API_KEY")
+    if not okey or not vkey:
+        raise ValueError("OPENAI_API_KEY and VAPI_API_KEY must be set")
+    agent = VapiAgent(okey, vkey)
+    agent.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/expense_manager/voice_agent.py
+++ b/expense_manager/voice_agent.py
@@ -1,0 +1,56 @@
+import os
+import openai
+import speech_recognition as sr
+import pyttsx3
+
+
+class VoiceAgent:
+    """A voice-powered agent that transcribes user input and responds using GPT."""
+
+    def __init__(self, openai_api_key: str):
+        openai.api_key = openai_api_key
+        self.recognizer = sr.Recognizer()
+        self.tts_engine = pyttsx3.init()
+
+    def listen(self) -> str:
+        with sr.Microphone() as source:
+            print("Listening...")
+            audio = self.recognizer.listen(source)
+        try:
+            text = self.recognizer.recognize_google(audio)
+            print(f"User said: {text}")
+            return text
+        except sr.UnknownValueError:
+            print("Could not understand audio")
+            return ""
+
+    def respond(self, prompt: str) -> str:
+        if not prompt:
+            return ""
+        completion = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo", messages=[{"role": "user", "content": prompt}]
+        )
+        answer = completion.choices[0].message["content"].strip()
+        print(f"Assistant: {answer}")
+        self.tts_engine.say(answer)
+        self.tts_engine.runAndWait()
+        return answer
+
+    def run(self):
+        while True:
+            prompt = self.listen()
+            if prompt.lower() in {"exit", "quit", "stop"}:
+                break
+            self.respond(prompt)
+
+
+def main():
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        raise ValueError("OPENAI_API_KEY environment variable not set")
+    agent = VoiceAgent(api_key)
+    agent.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/main.py
+++ b/main.py
@@ -1,0 +1,31 @@
+import argparse
+import os
+
+from expense_manager.voice_agent import VoiceAgent
+from expense_manager.vapi_agent import VapiAgent
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run the expense voice agent")
+    parser.add_argument(
+        "--vapi", action="store_true", help="Use the Vapi-based voice agent"
+    )
+    args = parser.parse_args()
+
+    openai_key = os.environ.get("OPENAI_API_KEY")
+    if not openai_key:
+        raise ValueError("OPENAI_API_KEY environment variable not set")
+
+    if args.vapi:
+        vapi_key = os.environ.get("VAPI_API_KEY")
+        if not vapi_key:
+            raise ValueError("VAPI_API_KEY environment variable not set")
+        agent = VapiAgent(openai_key, vapi_key)
+    else:
+        agent = VoiceAgent(openai_key)
+
+    agent.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+openai>=1.0.0
+SpeechRecognition>=3.8.1
+pyttsx3>=2.90
+requests>=2.31.0

--- a/tests/test_vapi_agent.py
+++ b/tests/test_vapi_agent.py
@@ -1,0 +1,34 @@
+import sys
+import types
+import unittest
+from unittest.mock import patch, MagicMock
+
+# Dummy modules for external dependencies
+sys.modules.setdefault('openai', types.ModuleType('openai'))
+sr_module = types.ModuleType('speech_recognition')
+sr_module.Recognizer = MagicMock()
+sr_module.Microphone = MagicMock()
+sys.modules.setdefault('speech_recognition', sr_module)
+requests_module = types.ModuleType('requests')
+requests_module.post = lambda *args, **kwargs: None
+sys.modules.setdefault('requests', requests_module)
+sys.modules.setdefault('pyttsx3', types.ModuleType('pyttsx3'))
+
+from expense_manager.vapi_agent import VapiAgent
+
+
+class TestVapiAgent(unittest.TestCase):
+    @patch('expense_manager.vapi_agent.requests.post')
+    @patch('expense_manager.vapi_agent.openai')
+    def test_run_once_exit(self, mock_openai, mock_post):
+        agent = VapiAgent('ok', 'vk')
+        with patch.object(agent, 'listen', return_value='exit'):
+            with patch.object(agent, 'speak') as mock_speak:
+                agent.run()
+        mock_speak.assert_not_called()
+        mock_post.assert_not_called()
+        mock_openai.ChatCompletion.create.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_voice_agent.py
+++ b/tests/test_voice_agent.py
@@ -1,0 +1,39 @@
+import sys
+import types
+import unittest
+from unittest.mock import patch, MagicMock
+
+# Create dummy modules for external dependencies so the import works
+sys.modules['openai'] = types.ModuleType('openai')
+sys.modules['speech_recognition'] = types.ModuleType('speech_recognition')
+sys.modules['pyttsx3'] = types.ModuleType('pyttsx3')
+
+from expense_manager.voice_agent import VoiceAgent
+
+
+class TestVoiceAgent(unittest.TestCase):
+    @patch("expense_manager.voice_agent.sr")
+    @patch("expense_manager.voice_agent.openai")
+    @patch("expense_manager.voice_agent.pyttsx3")
+    def test_run_once(self, mock_tts, mock_openai, mock_sr):
+        recognizer = MagicMock()
+        recognizer.listen.return_value = "audio"
+        recognizer.recognize_google.return_value = "hello"
+        mock_sr.Recognizer.return_value = recognizer
+        microphone = MagicMock()
+        mock_sr.Microphone.return_value.__enter__.return_value = microphone
+
+        mock_openai.ChatCompletion.create.return_value = MagicMock(
+            choices=[MagicMock(message={"content": "hi there"})]
+        )
+        engine = MagicMock()
+        mock_tts.init.return_value = engine
+
+        agent = VoiceAgent("key")
+        with patch.object(agent, "listen", return_value="exit"):
+            agent.run()
+        engine.say.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `VapiAgent` using Vapi REST API for STT/TTS
- allow choosing between local agent and Vapi agent via `--vapi`
- document the new option and environment variables in README
- add dependency on `requests`
- unit tests for the new agent

## Testing
- `python -m unittest discover -v tests`